### PR TITLE
Fix: incorrect mount option for NFS version > 3 , changed to python3-pip

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
     testslave.vm.hostname = "testslave.yourdomain"
     testslave.vm.network "private_network", ip: "192.168.56.142"
     testslave.vm.network "forwarded_port", guest: 3306, host: 3326
-    testslave.vm.synced_folder "./testslave", "/vagrant", type: "nfs", create: true
+    testslave.vm.synced_folder "./testslave", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false, create: true
     testslave.vm.provider :virtualbox do |vb|
       vb.customize ["modifyvm", :id, "--cpus", 1]
       vb.customize ["modifyvm", :id, "--ioapic", "on"]
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
     master.ssh.forward_agent = true
     master.vm.hostname = "master.yourdomain"
     master.vm.network "private_network", ip: "192.168.56.143"
-    master.vm.synced_folder "./master", "/vagrant", type: "nfs", create: true
+    master.vm.synced_folder "./master", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false, create: true
     master.vm.provider :virtualbox do |vb|
       vb.customize ["modifyvm", :id, "--cpus", 1]
       vb.customize ["modifyvm", :id, "--ioapic", "on"]

--- a/master/bin/installAnsible2.sh
+++ b/master/bin/installAnsible2.sh
@@ -2,7 +2,7 @@
 
 if [ ! -f "/usr/bin/ansible" ];
 then
-    sudo apt-get install -y build-essential libssl-dev libffi-dev python-dev python-pip
+    sudo apt-get install -y build-essential libssl-dev libffi-dev python-dev python3-pip
     sudo pip install ansible --upgrade
     if [ ! -e "/usr/bin/ansible" ];
     then


### PR DESCRIPTION
Mounting shared NFS directory in boxes master and testslave failed due to UDP being an invalid transport protocol for newer NFS versions (4.0+), see [RFC5661](https://datatracker.ietf.org/doc/html/rfc5661#section-2.9.1) and [Vagrant docs](https://www.vagrantup.com/docs/synced-folders/nfs).

![2022-07-01-142727_4480x1440_scrot2](https://user-images.githubusercontent.com/81679414/176910159-1fbbfb4f-5a65-4feb-b868-4e74f85946c6.png)

Solved for newer versions by also setting nfs_version: 4, nfs_udp: false as options.

Also changed installAnsible2.sh to use python3-pip due to python-pip being depreciated.